### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# multimethod
+
+This library provides multimethods for Racket. [For more information, see the documentation.](https://docs.racket-lang.org/multimethod/index.html)

--- a/multimethod-doc/scribblings/multimethod.scrbl
+++ b/multimethod-doc/scribblings/multimethod.scrbl
@@ -30,6 +30,9 @@ Multimethods provide similar but distinct functionality from @racketmodname[rack
 permits enhancing implementing structures in more powerful ways, but only supports
 @emph{single dispatch}.
 
+For more information on the initial design, see
+@hyperlink["https://lexi-lambda.github.io/blog/2016/02/18/simple-safe-multimethods-in-racket/"]{this blog post}.
+
 @section{Example}
 
 @(interaction

--- a/multimethod-doc/scribblings/multimethod.scrbl
+++ b/multimethod-doc/scribblings/multimethod.scrbl
@@ -3,7 +3,7 @@
 @(require racket/require
           (for-label multimethod
                      (subtract-in
-                      (multi-in racket [base function])
+                      (multi-in racket [base contract/base function])
                       multimethod))
           scribble/eval)
 
@@ -98,3 +98,7 @@ modules, which would cause problems when both loaded at the same time.}
 Like @base:struct from @racketmodname[racket/base], but wrapped to cooperate with the instance
 validity checking of @racket[define-instance]. Additionally, all structs defined with this form are
 @racket[#:transparent]. Otherwise identical to @|base:struct|.}
+
+@defproc[(multimethod? [v any/c]) boolean?]{
+Returns @racket[#t] if @racket[v] is a multimethod, @racket[#f] otherwise.
+}

--- a/multimethod-lib/multimethod/multimethod.rkt
+++ b/multimethod-lib/multimethod/multimethod.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-(require racket/function
+(require racket/contract/base
+         racket/function
          racket/struct-info
          (for-syntax racket/base
                      racket/function
@@ -9,22 +10,32 @@
                      racket/struct-info
                      racket/syntax
                      syntax/parse
+                     syntax/transformer
                      "privilege.rkt"))
 
 (provide (rename-out [privileged-struct struct])
+         (contract-out (rename multimethod-descriptor? multimethod? (-> any/c boolean?)))
          define-generic define-instance)
+
+; runtime representation of a multimethod
+(struct multimethod-descriptor (name relevant-indices dispatch-table)
+  #:methods gen:custom-write
+  [(define (write-proc method port mode)
+     (fprintf port "#<multimethod:~a>" (multimethod-descriptor-name method)))]
+  #:property prop:procedure
+  (lambda (method . args)
+    (apply-multimethod (multimethod-descriptor-name method)
+                       (multimethod-descriptor-relevant-indices method)
+                       (multimethod-descriptor-dispatch-table method)
+                       args)))
 
 (begin-for-syntax
   ; compile-time representation of a multimethod binding
-  (struct multimethod (arity dispatch-table)
-    #:transparent
+  (struct multimethod-binding (arity descriptor)
     #:property prop:procedure
-    (λ (method stx)
-      (syntax-parse stx
-        [(method arg ...)
-         #'(apply-multimethod method (list arg ...))]
-        [method
-         #'(λ args (apply-multimethod method args))])))
+    (lambda (method stx)
+      (let ([descriptor (multimethod-binding-descriptor method)])
+        ((make-variable-like-transformer descriptor) stx))))
   
   ; each multimethod has a total arity and a set of indices for which dispatch is actually performed
   ; for example, consider the definition of “map” — it has a total arity of 2, but dispatch is only
@@ -34,18 +45,18 @@
   ; handles parsing multimethod arg lists into expressions that produce dispatch-arity structs
   (define-splicing-syntax-class multimethod-arity-spec
     #:attributes [dispatch-arity-expr]
-    [pattern (~seq arg:id ...)
+    [pattern (~seq arg:id ...+)
              #:attr dispatch-arity-expr
-             #`(dispatch-arity #,(length (attribute arg))
-                               '#,(for/list ([(id n) (in-indexed (attribute arg))]
-                                             #:unless (free-identifier=? id #'_))
-                                    n))])
+             (dispatch-arity (length (attribute arg))
+                             (for/list ([(id n) (in-indexed (attribute arg))]
+                                        #:unless (free-identifier=? id #'_))
+                               n))
+             #:fail-when (empty? (dispatch-arity-relevant-indices (attribute dispatch-arity-expr)))
+             "expected at least one dispatch parameter"])
 
-  (define (assert-privileged-struct! id)
-    (unless (id-privileged? id)
-      (raise-syntax-error 'define-instance
-                          "expected name of struct defined in current module"
-                          id))))
+  ; wrapper around syntax-local-value with better error messages
+  (define ((assert-syntax-local-value name) id-stx)
+    (syntax-local-value id-stx (lambda () (raise-syntax-error name "unbound identifier" id-stx)))))
 
 ; replacement for the struct form that associates privilege information
 (define-syntax privileged-struct
@@ -57,56 +68,54 @@
 (define-syntax define-generic
   (syntax-parser
     [(_ (method:id arity-spec:multimethod-arity-spec))
-     (with-syntax ([dispatch-table (generate-temporary #'method)])
-       (mark-id-as-privileged! #'method)
-       #'(begin
-           (define dispatch-table (make-hash))
-           (define-syntax method (multimethod arity-spec.dispatch-arity-expr #'dispatch-table))))]))
+     (let* ([arity (attribute arity-spec.dispatch-arity-expr)]
+            [relevant-indices (dispatch-arity-relevant-indices arity)])
+       (with-syntax ([descriptor (generate-temporary #'method)]
+                     [arity arity]
+                     [relevant-indices relevant-indices])
+         (mark-id-as-privileged! #'method)
+         #'(begin
+             (define descriptor (multimethod-descriptor 'method 'relevant-indices (make-hash)))
+             (define-syntax method (multimethod-binding arity #'descriptor)))))]))
 
 (define-syntax define-instance
   (syntax-parser
     ; standard (define (proc ...) ...) shorthand
-    [(_ ((method type:id ...+) . args) body:expr ...+)
-     #'(define-instance (method type ...) (λ args body ...))]
+    [(_ ((~and signature (method type:id ...+)) . args) body:expr ...+)
+     #'(define-instance signature (λ args body ...))]
     ; full (define proc lambda-expr) notation
-    [(_ (method type:id ...+) proc:expr)
-     (let* ([multimethod (syntax-local-value #'method)]
+    [(_ (~and signature (method type:id ...+)) proc:expr)
+     (let* ([multimethod ((assert-syntax-local-value 'define-instance) #'method)]
             [privileged? (id-privileged? #'method)])
+       (unless (multimethod-binding? multimethod)
+         (raise-syntax-error 'define-instance
+                             "expected multimethod binding"
+                             #'method))
        ; don’t check struct privilege if the multimethod is itself privileged
        (unless (or privileged? (ormap id-privileged? (attribute type)))
-         (assert-privileged-struct! (first (attribute type))))
-       (with-syntax ([dispatch-table (multimethod-dispatch-table multimethod)]
-                     [(struct-type-id ...) (map (compose1 first extract-struct-info syntax-local-value)
+         (raise-syntax-error 'define-instance
+                             "expected name of multimethod or struct defined in current module"
+                             #'signature))
+       (with-syntax ([descriptor (multimethod-binding-descriptor multimethod)]
+                     [(struct-type-id ...) (map (compose1 first
+                                                          extract-struct-info
+                                                          (assert-syntax-local-value 'define-instance))
                                                 (attribute type))])
          #'(let ([struct-types (list struct-type-id ...)])
-             (hash-set! dispatch-table struct-types proc))))]))
+             (hash-set! (multimethod-descriptor-dispatch-table descriptor) struct-types proc))))]))
 
 ; wrapper around struct-info that throws away the second value
 (define (struct-type-info s)
   (let-values ([(type complete?) (struct-info s)])
     type))
 
-; application hook for multimethods; expands into do-apply-multimethod
-(define-syntax apply-multimethod
-  (syntax-parser
-    [(_ method args:expr)
-     (let ([multimethod (syntax-local-value #'method)])
-       (with-syntax ([dispatch-table (multimethod-dispatch-table multimethod)]
-                     [relevant-indices (dispatch-arity-relevant-indices
-                                        (multimethod-arity multimethod))])
-         #'(do-apply-multimethod dispatch-table (filter-indices 'relevant-indices) args)))]))
-
-; Given a list of indices and a list, returns a list with only the elements at the specified
-; indices. Used to get the args needed for dispatch from the arity’s relevant-indices.
-; (listof exact-nonnegative-integer?) -> list? -> list?
-(define ((filter-indices indices) lst)
-  (for/list ([(x i) (in-indexed lst)]
-             #:when (member i indices))
-    x))
-
 ; runtime implementation of multimethod dispatch and invocation
-(define (do-apply-multimethod dispatch-table map-args-to-dispatch args)
-  (apply (hash-ref dispatch-table (map struct-type-info (map-args-to-dispatch args))) args))
+(define (apply-multimethod name relevant-indices dispatch-table args)
+  (let ([dispatch-args (for/list ([(x i) (in-indexed args)]
+                                  #:when (member i relevant-indices))
+                         (or (struct-type-info x)
+                             (apply raise-argument-error name "transparent struct" i args)))])
+    (apply (hash-ref dispatch-table dispatch-args (lambda () (raise-user-error name "no multimethod instance found for ~a" (map object-name dispatch-args)))) args)))
 
 (begin-for-syntax
   (module+ test
@@ -115,20 +124,17 @@
 
     (describe ":multimethod-arity-spec"
       (it "parses syntax to dispatch-arity structs"
-        (check-equal? (syntax->datum
-                       (syntax-parse #'(a b c d)
-                         [(arity-spec:multimethod-arity-spec)
-                          (attribute arity-spec.dispatch-arity-expr)]))
-                      '(dispatch-arity 4 '(0 1 2 3)))
+        (check-equal? (syntax-parse #'(a b c d)
+                        [(arity-spec:multimethod-arity-spec)
+                         (attribute arity-spec.dispatch-arity-expr)])
+                      (dispatch-arity 4 '(0 1 2 3)))
         
-        (check-equal? (syntax->datum
-                       (syntax-parse #'(_ f _ _)
-                         [(arity-spec:multimethod-arity-spec)
-                          (attribute arity-spec.dispatch-arity-expr)]))
-                      '(dispatch-arity 4 '(1)))
+        (check-equal? (syntax-parse #'(_ f _ _)
+                        [(arity-spec:multimethod-arity-spec)
+                         (attribute arity-spec.dispatch-arity-expr)])
+                      (dispatch-arity 4 '(1)))
         
-        (check-equal? (syntax->datum
-                       (syntax-parse #'(_ a _ b _)
-                         [(arity-spec:multimethod-arity-spec)
-                          (attribute arity-spec.dispatch-arity-expr)]))
-                      '(dispatch-arity 5 '(1 3)))))))
+        (check-equal? (syntax-parse #'(_ a _ b _)
+                        [(arity-spec:multimethod-arity-spec)
+                         (attribute arity-spec.dispatch-arity-expr)])
+                      (dispatch-arity 5 '(1 3)))))))

--- a/multimethod-lib/multimethod/multimethod.rkt
+++ b/multimethod-lib/multimethod/multimethod.rkt
@@ -26,10 +26,10 @@
         [method
          #'(λ args (apply-multimethod method args))])))
   
-  ; each multimethod has a total arity and a set of indicies for which dispatch is actually performed
+  ; each multimethod has a total arity and a set of indices for which dispatch is actually performed
   ; for example, consider the definition of “map” — it has a total arity of 2, but dispatch is only
   ; performed on the second argument
-  (struct dispatch-arity (total relevant-indicies) #:transparent)
+  (struct dispatch-arity (total relevant-indices) #:transparent)
 
   ; handles parsing multimethod arg lists into expressions that produce dispatch-arity structs
   (define-splicing-syntax-class multimethod-arity-spec
@@ -92,16 +92,16 @@
     [(_ method args:expr)
      (let ([multimethod (syntax-local-value #'method)])
        (with-syntax ([dispatch-table (multimethod-dispatch-table multimethod)]
-                     [relevant-indicies (dispatch-arity-relevant-indicies
-                                         (multimethod-arity multimethod))])
-         #'(do-apply-multimethod dispatch-table (filter-indicies 'relevant-indicies) args)))]))
+                     [relevant-indices (dispatch-arity-relevant-indices
+                                        (multimethod-arity multimethod))])
+         #'(do-apply-multimethod dispatch-table (filter-indices 'relevant-indices) args)))]))
 
-; Given a list of indicies and a list, returns a list with only the elements at the specified
-; indicies. Used to get the args needed for dispatch from the arity’s relevant-indicies.
+; Given a list of indices and a list, returns a list with only the elements at the specified
+; indices. Used to get the args needed for dispatch from the arity’s relevant-indices.
 ; (listof exact-nonnegative-integer?) -> list? -> list?
-(define ((filter-indicies indicies) lst)
+(define ((filter-indices indices) lst)
   (for/list ([(x i) (in-indexed lst)]
-             #:when (member i indicies))
+             #:when (member i indices))
     x))
 
 ; runtime implementation of multimethod dispatch and invocation

--- a/multimethod-lib/multimethod/multimethod.rkt
+++ b/multimethod-lib/multimethod/multimethod.rkt
@@ -36,7 +36,7 @@
     (lambda (method stx)
       (let ([descriptor (multimethod-binding-descriptor method)])
         ((make-variable-like-transformer descriptor) stx))))
-  
+
   ; each multimethod has a total arity and a set of indices for which dispatch is actually performed
   ; for example, consider the definition of “map” — it has a total arity of 2, but dispatch is only
   ; performed on the second argument
@@ -128,13 +128,18 @@
                         [(arity-spec:multimethod-arity-spec)
                          (attribute arity-spec.dispatch-arity-expr)])
                       (dispatch-arity 4 '(0 1 2 3)))
-        
+
         (check-equal? (syntax-parse #'(_ f _ _)
                         [(arity-spec:multimethod-arity-spec)
                          (attribute arity-spec.dispatch-arity-expr)])
                       (dispatch-arity 4 '(1)))
-        
+
         (check-equal? (syntax-parse #'(_ a _ b _)
                         [(arity-spec:multimethod-arity-spec)
                          (attribute arity-spec.dispatch-arity-expr)])
-                      (dispatch-arity 5 '(1 3)))))))
+                      (dispatch-arity 5 '(1 3)))
+
+        (check-exn exn:fail:syntax?
+                   (lambda ()
+                     (syntax-parse #'(_ _)
+                       [(arity-spec:multimethod-arity-spec) '()])))))))

--- a/multimethod-test/tests/multimethod/multimethod.rkt
+++ b/multimethod-test/tests/multimethod/multimethod.rkt
@@ -43,6 +43,9 @@
          'generic-definitions
          'extra-definitions)
 
+(check-true (multimethod? add))
+(check-equal? (format "~a" add) "#<multimethod:add>")
+
 (check-equal? (add (num 1) (num 2)) (num 3))
 (check-equal? (add (num 1) (vec '(1 2 3))) (vec '(2 3 4)))
 (check-equal? (add (vec '(1 2 3)) (num 1)) (vec '(2 3 4)))

--- a/multimethod-test/tests/multimethod/multimethod.rkt
+++ b/multimethod-test/tests/multimethod/multimethod.rkt
@@ -56,6 +56,6 @@
 (check-equal? (add (bool #t) (num 0)) (bool #t))
 (check-equal? (add (bool #f) (num 1)) (bool #t))
 
-(check-exn #rx"^define-instance: expected name of struct defined in current module$"
+(check-exn #rx"^define-instance: expected name of multimethod or struct defined in current module$"
            (thunk (convert-syntax-error (define-instance ((add num bool) n b)
                                           (bool (or (not (= (num-val n) 0)) (bool-val b)))))))


### PR DESCRIPTION
This PR does several error reporting improvements and changes the runtime representation of multimethods. For a list of all the changes, see below.

The runtime representation of a multimethod is now a `multimethod-descriptor` struct, which has several advantages. For example, it make it possible to create a `multimethod?` predicate and provide a custom string representation for multimethods. Example:

```rkt
> (define-generic (example a b))
> (multimethod? example)
#t
> example
#<multimethod:example>
```

API changes:
* new `multimethod?` predicate (along with a scribbling)
* custom string representation for multimethods
* more/better error messages

Other changes:
* create README.md
* multimethods are `multimethod-descriptor` structs now
* rename the `multimethod` struct type to `multimethod-binding`
* link the blog post in the documentation
* fix a typo
* more tests
* the `dispatch-arity` (formerly `dispatch-arity-expr`) attribute of `multimethod-arity-spec` returns the `dispatch-arity` struct now, instead of a syntax object